### PR TITLE
Serve POD uploads without signed URLs

### DIFF
--- a/app/admin/consignment_controller.py
+++ b/app/admin/consignment_controller.py
@@ -1,5 +1,6 @@
 import io
 import logging
+import mimetypes
 import re
 import os
 import uuid
@@ -68,6 +69,35 @@ def _store_pod_bytes(filename, file_bytes, content_type=None, bucket_name=None):
     with open(dest_path, "wb") as file_handle:
         file_handle.write(file_bytes)
     return filename
+
+
+def _parse_supabase_pod_value(pod_value):
+    if not isinstance(pod_value, str) or not pod_value.startswith('supabase:'):
+        raise ValueError('POD is not stored in Supabase.')
+
+    _, rest = pod_value.split(':', 1)
+    bucket, object_path = rest.split('/', 1)
+    if not bucket or not object_path:
+        raise ValueError('Invalid Supabase POD path.')
+
+    return bucket, object_path
+
+
+def _download_supabase_pod_file(pod_value):
+    client = _get_supabase_client()
+    if not client:
+        raise RuntimeError('Supabase not configured.')
+
+    bucket, object_path = _parse_supabase_pod_value(pod_value)
+    content = client.storage.from_(bucket).download(object_path)
+    if hasattr(content, 'read'):
+        content = content.read()
+    if isinstance(content, bytearray):
+        content = bytes(content)
+    if not isinstance(content, bytes):
+        raise RuntimeError('Unexpected Supabase download response.')
+
+    return content, object_path
 
 
 def _delete_pod_file(pod_value):
@@ -799,37 +829,19 @@ def consignment_pod_file(consignment_id):
         if pod_path.startswith("http://") or pod_path.startswith("https://"):
             return redirect(pod_path)
 
-        # Supabase-stored value: "supabase:bucket/path"
+        # Supabase-stored value: "supabase:bucket/path". Keep the app route as the
+        # stable POD URL and stream bytes directly instead of redirecting to a
+        # temporary storage URL.
         if isinstance(pod_path, str) and pod_path.startswith("supabase:"):
-            client = _get_supabase_client()
-            if not client:
-                return jsonify({"success": False, "message": "Supabase not configured."}), 500
             try:
-                # parse
-                _, rest = pod_path.split(":", 1)
-                bucket, object_path = rest.split("/", 1)
-                # Attempt to create a signed URL (30s) then redirect
-                try:
-                    signed = client.storage.from_(bucket).create_signed_url(object_path, 30)
-                    # supabase client may return dict with 'signedURL' or 'signed_url'
-                    url = None
-                    if isinstance(signed, dict):
-                        url = signed.get('signedURL') or signed.get('signed_url') or signed.get('signedUrl')
-                    if not url:
-                        # fallback to public URL
-                        pub = client.storage.from_(bucket).get_public_url(object_path)
-                        url = pub.get('publicURL') or pub.get('publicUrl') or pub.get('publicURL')
-                    if url:
-                        return redirect(url)
-                except Exception:
-                    # fallback to public url
-                    pub = client.storage.from_(bucket).get_public_url(object_path)
-                    url = pub.get('publicURL') or pub.get('publicUrl') or pub.get('publicURL')
-                    if url:
-                        return redirect(url)
-                return jsonify({"success": False, "message": "Unable to generate POD URL."}), 500
+                content, object_path = _download_supabase_pod_file(pod_path)
+                mimetype, _ = mimetypes.guess_type(object_path)
+                return send_file(io.BytesIO(content), mimetype=mimetype or "application/octet-stream")
+            except RuntimeError as error:
+                logger.exception("Error downloading Supabase POD file")
+                return jsonify({"success": False, "message": str(error)}), 500
             except Exception:
-                logger.exception("Error generating Supabase POD URL")
+                logger.exception("Error serving Supabase POD file")
                 return jsonify({"success": False, "message": "Failed to serve POD."}), 500
 
         # Otherwise treat as local filename under instance/uploads

--- a/app/db_maintenance.py
+++ b/app/db_maintenance.py
@@ -1,8 +1,6 @@
 import logging
 import threading
 
-import psycopg2
-
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +27,8 @@ def ensure_consignment_columns(dsn, log=None):
         raise ValueError("A PostgreSQL DSN is required to ensure consignment columns.")
 
     active_logger = log or logger
+
+    import psycopg2
 
     conn = psycopg2.connect(dsn)
     try:

--- a/app/track/routes.py
+++ b/app/track/routes.py
@@ -1,4 +1,5 @@
 import logging
+import mimetypes
 import re
 import io
 import os
@@ -98,39 +99,27 @@ def consignment_pod(consignment_number):
             except Exception:
                 return jsonify({"success": False, "message": "Failed to retrieve external POD."}), 502
 
-        # Supabase-stored value: "supabase:bucket/path"
+        # Supabase-stored value: "supabase:bucket/path". Keep this route as the
+        # permanent public download endpoint and stream bytes directly instead of
+        # redirecting users to a temporary storage URL.
         if isinstance(pod_path, str) and pod_path.startswith("supabase:"):
-            # import helper lazily to avoid circular imports
             try:
-                from app.admin.consignment_controller import _get_supabase_client
+                from app.admin.consignment_controller import _download_supabase_pod_file
+
+                content_bytes, object_path = _download_supabase_pod_file(pod_path)
+                mimetype, _ = mimetypes.guess_type(object_path)
+                filename = os.path.basename(object_path) or f"{number}_pod.jpg"
+                return send_file(
+                    io.BytesIO(content_bytes),
+                    as_attachment=True,
+                    download_name=filename,
+                    mimetype=mimetype or "application/octet-stream",
+                )
+            except RuntimeError as error:
+                logger.exception('Error downloading Supabase POD file')
+                return jsonify({"success": False, "message": str(error)}), 500
             except Exception:
-                _get_supabase_client = None
-
-            client = None
-            if _get_supabase_client:
-                client = _get_supabase_client()
-
-            if not client:
-                return jsonify({"success": False, "message": "Supabase not configured."}), 500
-
-            try:
-                _, rest = pod_path.split(":", 1)
-                bucket, object_path = rest.split("/", 1)
-                # create a short signed url and redirect the client to it
-                ttl = int(os.getenv('SUPABASE_SIGNED_URL_TTL', '30'))
-                signed = client.storage.from_(bucket).create_signed_url(object_path, ttl)
-                url = None
-                if isinstance(signed, dict):
-                    url = signed.get('signedURL') or signed.get('signed_url') or signed.get('signedUrl')
-                if not url:
-                    pub = client.storage.from_(bucket).get_public_url(object_path)
-                    url = pub.get('publicURL') or pub.get('publicUrl')
-                if not url:
-                    return jsonify({"success": False, "message": "Unable to generate POD URL."}), 500
-
-                return redirect(url)
-            except Exception:
-                logger.exception('Error generating Supabase POD URL')
+                logger.exception('Error serving Supabase POD file')
                 return jsonify({"success": False, "message": "Failed to serve POD."}), 500
 
         # Otherwise treat as local filename under instance/uploads

--- a/tests/test_pod_upload.py
+++ b/tests/test_pod_upload.py
@@ -138,3 +138,124 @@ def test_staged_pod_upload_saves_with_row(tmp_path):
         assert os.path.exists(pod_path)
         with open(pod_path, 'rb') as file_handle:
             assert file_handle.read() == pod_bytes
+
+
+class FakeSupabaseBucket:
+    def __init__(self, store, bucket_name):
+        self.store = store
+        self.bucket_name = bucket_name
+
+    def upload(self, object_path, file_obj, options=None):
+        self.store[(self.bucket_name, object_path)] = file_obj.read()
+        return {"path": object_path}
+
+    def download(self, object_path):
+        return self.store[(self.bucket_name, object_path)]
+
+    def remove(self, object_paths):
+        for object_path in object_paths:
+            self.store.pop((self.bucket_name, object_path), None)
+        return []
+
+
+class FakeSupabaseStorage:
+    def __init__(self, store):
+        self.store = store
+
+    def from_(self, bucket_name):
+        return FakeSupabaseBucket(self.store, bucket_name)
+
+
+class FakeSupabaseClient:
+    def __init__(self):
+        self.store = {}
+        self.storage = FakeSupabaseStorage(self.store)
+
+
+def test_supabase_pod_upload_serves_permanent_app_endpoint_without_signed_url(tmp_path, monkeypatch):
+    setup_env_for_app(tmp_path)
+
+    from app import create_app
+    from app.models import db, Consignment
+    import app.admin.consignment_controller as controller
+
+    fake_supabase = FakeSupabaseClient()
+    monkeypatch.setattr(controller, '_get_supabase_client', lambda: fake_supabase)
+    monkeypatch.setenv('SUPABASE_BUCKET', 'pod-uploads')
+
+    app = create_app()
+    app.instance_path = str(tmp_path / 'instance')
+    os.makedirs(app.instance_path, exist_ok=True)
+
+    client = app.test_client()
+
+    with app.app_context():
+        try:
+            db.drop_all()
+        except Exception:
+            pass
+        db.create_all()
+        c = Consignment(consignment_number='SUPACN1', status='In Transit')
+        db.session.add(c)
+        db.session.commit()
+        cid = c.id
+
+    from app.admin.auth import ADMIN_SESSION_KEY
+    with client.session_transaction() as sess:
+        sess[ADMIN_SESSION_KEY] = True
+
+    resp = client.post(
+        f'/admin/consignments/{cid}/pod',
+        data={'file': (BytesIO(b'supabase-pod-bytes'), 'pod.jpg')},
+        content_type='multipart/form-data',
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body and body.get('success') is True
+    assert body['pod_image'].startswith('supabase:pod-uploads/')
+
+    with app.app_context():
+        row = Consignment.query.get(cid)
+        assert row.pod_image == body['pod_image']
+
+    get_resp = client.get(f'/admin/consignments/{cid}/pod')
+    assert get_resp.status_code == 200
+    assert get_resp.data == b'supabase-pod-bytes'
+    assert get_resp.location is None
+
+
+def test_track_pod_streams_supabase_file_without_signed_url(tmp_path, monkeypatch):
+    setup_env_for_app(tmp_path)
+
+    from app import create_app
+    from app.models import db, Consignment
+    import app.admin.consignment_controller as controller
+
+    fake_supabase = FakeSupabaseClient()
+    fake_supabase.store[('pod-uploads', '42/pod.jpg')] = b'track-supabase-pod-bytes'
+    monkeypatch.setattr(controller, '_get_supabase_client', lambda: fake_supabase)
+
+    app = create_app()
+    app.instance_path = str(tmp_path / 'instance')
+    os.makedirs(app.instance_path, exist_ok=True)
+
+    client = app.test_client()
+
+    with app.app_context():
+        try:
+            db.drop_all()
+        except Exception:
+            pass
+        db.create_all()
+        db.session.add(Consignment(
+            consignment_number='TRKCN1',
+            status='Delivered',
+            pod_image='supabase:pod-uploads/42/pod.jpg',
+        ))
+        db.session.commit()
+
+    get_resp = client.get('/track/pod/TRKCN1')
+    assert get_resp.status_code == 200
+    assert get_resp.data == b'track-supabase-pod-bytes'
+    assert get_resp.location is None
+    assert 'attachment' in get_resp.headers.get('Content-Disposition', '')


### PR DESCRIPTION
### Motivation
- Signed short-lived URLs made PODs inaccessible once they expired and prevented the app from serving a permanent POD URL for uploaded files.
- The change ensures PODs uploaded to Supabase are retrievable indefinitely via the app's stable endpoints rather than relying on temporary storage links.

### Description
- Added Supabase helpers `_parse_supabase_pod_value` and `_download_supabase_pod_file` to parse the `supabase:<bucket>/<path>` marker and fetch raw bytes from Supabase storage (app/admin/consignment_controller.py).
- Updated admin POD GET handler `/admin/consignments/<id>/pod` to stream Supabase-stored bytes through the app endpoint instead of redirecting to a signed/temporary URL (app/admin/consignment_controller.py).
- Updated public track POD endpoint `/track/pod/<consignment_number>` to stream Supabase-stored POD bytes as an attachment via the permanent route rather than issuing a signed redirect (app/track/routes.py).
- Deferred the `psycopg2` import into the DB maintenance function to avoid import-time failures in test/development environments where the binary driver may be unavailable (app/db_maintenance.py).
- Added tests that use a fake Supabase client to verify Supabase upload persistence and that both admin and public endpoints serve bytes directly (tests/test_pod_upload.py).

### Testing
- Ran `python -m compileall app tests/test_pod_upload.py` which succeeded.
- Ran `python -m pytest tests/test_pod_upload.py -q` and all added/related POD tests passed (4 passed, warnings only).
- Ran `python -m pytest -q` for the full suite which failed during collection due to a missing test dependency (`jsonschema`) in the environment, not because of the POD changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a265f83ed5c8332bfe7c7ffc5044952)